### PR TITLE
fix: add support for classes with decorators

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "babel-plugin-transform-class-inject-directive",
     "description": "Detect an inject directive on a class constructor and define a static property with the list of dependencies.",
     "homepage": "https://homer0.github.io/babel-plugin-transform-class-inject-directive/",
-    "version": "3.0.1",
+    "version": "3.0.2",
     "repository": "homer0/babel-plugin-transform-class-inject-directive",
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",

--- a/src/injectDirectiveParser.js
+++ b/src/injectDirectiveParser.js
@@ -290,10 +290,10 @@ class InjectDirectiveParser {
     }
   }
   /**
-   * When used with decorators, Babel puts the class inside a nested sequense expression that
+   * When used with decorators, Babel puts the class inside a nested sequence expression that
    * applies the decorators, and if this plugin were to add the `inject` property right after the
-   * class parent, it can end up in the middle of the sequense and make the code invalid.
-   * This method validates if the class is inside a sequense and crawls the path all the way up
+   * class parent, it can end up in the middle of the sequence and make the code invalid.
+   * This method validates if the class is inside a sequence and crawls the path all the way up
    * to the variable declaration (child of the program).
    * @param {Path} path The current {@link Path} that was going to be used for the class.
    * @return {Path}
@@ -309,6 +309,7 @@ class InjectDirectiveParser {
       babelTypes.isSequenceExpression(result.parentPath.parent)
     ) {
       result = result.parentPath.parentPath;
+
       while (result.parentPath && !babelTypes.isProgram(result.parentPath)) {
         result = result.parentPath;
       }

--- a/src/injectDirectiveParser.js
+++ b/src/injectDirectiveParser.js
@@ -278,6 +278,7 @@ class InjectDirectiveParser {
     if (babelTypes.isClass(node)) {
       ({ name } = node.id);
       node = this._getClassConstructor(node);
+      topPath = this._findProperClassPath(topPath);
     }
 
     if (node.params.length) {
@@ -287,6 +288,33 @@ class InjectDirectiveParser {
         this._addPropertyBeforePath(node.params, path, node.id.name);
       }
     }
+  }
+  /**
+   * When used with decorators, Babel puts the class inside a nested sequense expression that
+   * applies the decorators, and if this plugin were to add the `inject` property right after the
+   * class parent, it can end up in the middle of the sequense and make the code invalid.
+   * This method validates if the class is inside a sequense and crawls the path all the way up
+   * to the variable declaration (child of the program).
+   * @param {Path} path The current {@link Path} that was going to be used for the class.
+   * @return {Path}
+   * @access protected
+   * @ignore
+   */
+  _findProperClassPath(topPath) {
+    let result = topPath;
+    if (
+      result.parent &&
+      babelTypes.isAssignmentExpression(result.parent) &&
+      result.parentPath.parent &&
+      babelTypes.isSequenceExpression(result.parentPath.parent)
+    ) {
+      result = result.parentPath.parentPath;
+      while (result.parentPath && !babelTypes.isProgram(result.parentPath)) {
+        result = result.parentPath;
+      }
+    }
+
+    return result;
   }
 }
 


### PR DESCRIPTION
### What does this PR do?

When using decorators with Babel, Babel creates a sequence wrapper in order to apply the decorators, something like this:

```js
let Hello = (_class = (_temp = (_temp2 = class Hello {
  constructor(someService) {
    'inject';

    _initializerDefineProperty(this, "random", _descriptor, this);
  }
}, _temp2), _temp), (_descriptor = _applyDecoratedDescriptor(_class.prototype, "random", [aurelia_framework__WEBPACK_IMPORTED_MODULE_0__["bindable"]], {
  configurable: true,
  enumerable: true,
  writable: true,
  initializer: function () {
    return 'something';
  }
})), _class);
```

And when this plugin tries to add the `inject` property, it ends up between the class expression and `_temp2`, making the code invalid and breaking the execution.

The solution I implemented here is that, when working with a class, if the class is inside a sequence expression, the plugin will crawl all the way up until the top path is the program itself, and then add the definition:

```diff
})), _class);
+ Hello.inject = ['something'];
```

> Yes, I'm not good at working with Babel ASTs :P.

### How should it be tested manually?

1. Try using the current release on a class with a decorator, it should break.
2. Use this branch and everything should go back like it was before.
